### PR TITLE
fix(VIP-858): upgrade follow-redirects (GHSA-r4q5-vmmm-2653)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3297,9 +3297,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "moment": "^2.30.1",
     "axios": "^1.15.0",
     "js-base64": "^3.7.8"
+  },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds an `overrides` block in `package.json` to force `follow-redirects` to `^1.16.0`
- Remediates **GHSA-r4q5-vmmm-2653** (high severity): improper filtering of URLs that redirect to unexpected hosts
- `follow-redirects` is a transitive dependency pulled in by `axios` (runtime) and `http-server` (dev); neither can be upgraded to a version that already depends on >=1.16.0 without breaking changes, so the override is the correct fix
- After `npm install` both paths resolve to `follow-redirects@1.16.0` (verified via `npm ls follow-redirects`)

## Test plan

- [ ] `npm install` completes without errors
- [ ] `npm ls follow-redirects` shows `1.16.0` for every resolved instance (no older version present)
- [ ] `npm test` passes (runs jasmine suite)
- [ ] `npm run prod` builds dist artefacts successfully

## References

- Aikido advisory: GHSA-r4q5-vmmm-2653
- VIP-858

🤖 Generated with [Claude Code](https://claude.com/claude-code)