### PR TITLE
fix(VIP-858): bump axios to 1.15.1, add follow-redirects override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "babel-runtime": "^6.26.0",
         "cached-path-relative": "^1.1.0",
         "js-base64": "^3.7.8",
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -3297,9 +3297,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "babel-runtime": "^6.26.0",
     "cached-path-relative": "^1.1.0",
     "moment": "^2.30.1",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "js-base64": "^3.7.8"
+  },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
   }
 }


### PR DESCRIPTION
## Summary

- `axios` `^1.15.0` → `^1.15.1` — fixes AIKIDO-2026-10509 (prototype pollution)
- Add `overrides: { "follow-redirects": "^1.16.0" }` — fixes GHSA-r4q5-vmmm-2653

Builds on the previous VIP-858 round of fixes already on this branch.

## Test plan

- [ ] `npm audit` shows no high/critical findings for axios or follow-redirects
- [ ] Tokenizer smoke test (card tokenization flow) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)